### PR TITLE
Throw exception with meaningful error description in case of missing state definition.

### DIFF
--- a/src/main/kotlin/com/tinder/StateMachine.kt
+++ b/src/main/kotlin/com/tinder/StateMachine.kt
@@ -51,7 +51,7 @@ class StateMachine<STATE : Any, EVENT : Any, SIDE_EFFECT : Any> private construc
     private fun STATE.getDefinition() = graph.stateDefinitions
         .filter { it.key.matches(this) }
         .map { it.value }
-        .firstOrNull() ?: error("Missing definition for state $this!")
+        .firstOrNull() ?: error("Missing definition for state ${this.javaClass.simpleName}!")
 
     private fun STATE.notifyOnEnter(cause: EVENT) {
         getDefinition().onEnterListeners.forEach { it(this, cause) }

--- a/src/main/kotlin/com/tinder/StateMachine.kt
+++ b/src/main/kotlin/com/tinder/StateMachine.kt
@@ -51,8 +51,7 @@ class StateMachine<STATE : Any, EVENT : Any, SIDE_EFFECT : Any> private construc
     private fun STATE.getDefinition() = graph.stateDefinitions
         .filter { it.key.matches(this) }
         .map { it.value }
-        .firstOrNull()
-        .let { checkNotNull(it) }
+        .firstOrNull() ?: error("Missing definition for state $this!")
 
     private fun STATE.notifyOnEnter(cause: EVENT) {
         getDefinition().onEnterListeners.forEach { it(this, cause) }

--- a/src/test/kotlin/com/tinder/StateMachineTest.kt
+++ b/src/test/kotlin/com/tinder/StateMachineTest.kt
@@ -713,11 +713,9 @@ internal class StateMachineTest {
             @Test
             fun transition_givenMissingDestinationStateDefinition_shouldThrowIllegalStateExceptionWithStateName() {
                 // Then
-                try {
-                    stateMachine.transition(EVENT_1)
-                } catch (e: IllegalStateException) {
-                    assertThat(e.message).contains(STATE_B)
-                }
+                assertThatIllegalStateException()
+                        .isThrownBy { stateMachine.transition(EVENT_1) }
+                        .withMessage("Missing definition for state ${STATE_B.javaClass.simpleName}!")
             }
         }
 

--- a/src/test/kotlin/com/tinder/StateMachineTest.kt
+++ b/src/test/kotlin/com/tinder/StateMachineTest.kt
@@ -2,7 +2,9 @@ package com.tinder
 
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.then
-import org.assertj.core.api.Assertions.*
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
+import org.assertj.core.api.Assertions.assertThatIllegalStateException
 import org.junit.Test
 import org.junit.experimental.runners.Enclosed
 import org.junit.runner.RunWith

--- a/src/test/kotlin/com/tinder/StateMachineTest.kt
+++ b/src/test/kotlin/com/tinder/StateMachineTest.kt
@@ -698,7 +698,7 @@ internal class StateMachineTest {
             }
         }
 
-        class WithIncompleteStateDefinition {
+        class WithMissingStateDefinition {
 
             private val stateMachine = StateMachine.create<String, Int, Nothing> {
                 initialState(STATE_A)

--- a/src/test/kotlin/com/tinder/StateMachineTest.kt
+++ b/src/test/kotlin/com/tinder/StateMachineTest.kt
@@ -698,7 +698,7 @@ internal class StateMachineTest {
 
         class WithIncompleteStateDefinition {
 
-            private val stateMachine = StateMachine.create<String, Int, String> {
+            private val stateMachine = StateMachine.create<String, Int, Nothing> {
                 initialState(STATE_A)
                 state(STATE_A) {
                     on(EVENT_1) {

--- a/src/test/kotlin/com/tinder/StateMachineTest.kt
+++ b/src/test/kotlin/com/tinder/StateMachineTest.kt
@@ -719,7 +719,6 @@ internal class StateMachineTest {
             }
         }
 
-
         private companion object {
             private const val STATE_A = "a"
             private const val STATE_B = "b"

--- a/src/test/kotlin/com/tinder/StateMachineTest.kt
+++ b/src/test/kotlin/com/tinder/StateMachineTest.kt
@@ -2,9 +2,7 @@ package com.tinder
 
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.then
-import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
-import org.assertj.core.api.Assertions.assertThatIllegalStateException
+import org.assertj.core.api.Assertions.*
 import org.junit.Test
 import org.junit.experimental.runners.Enclosed
 import org.junit.runner.RunWith
@@ -697,6 +695,30 @@ internal class StateMachineTest {
                 }
             }
         }
+
+        class WithIncompleteStateDefinition {
+
+            private val stateMachine = StateMachine.create<String, Int, String> {
+                initialState(STATE_A)
+                state(STATE_A) {
+                    on(EVENT_1) {
+                        transitionTo(STATE_B)
+                    }
+                }
+                // Missing STATE_B definition.
+            }
+
+            @Test
+            fun transition_givenValidEvent_shouldReturnTrue() {
+                // Then
+                try {
+                    stateMachine.transition(EVENT_1)
+                } catch (e: IllegalStateException) {
+                    assertThat(e.message).contains(STATE_B)
+                }
+            }
+        }
+
 
         private companion object {
             private const val STATE_A = "a"

--- a/src/test/kotlin/com/tinder/StateMachineTest.kt
+++ b/src/test/kotlin/com/tinder/StateMachineTest.kt
@@ -714,8 +714,8 @@ internal class StateMachineTest {
             fun transition_givenMissingDestinationStateDefinition_shouldThrowIllegalStateExceptionWithStateName() {
                 // Then
                 assertThatIllegalStateException()
-                        .isThrownBy { stateMachine.transition(EVENT_1) }
-                        .withMessage("Missing definition for state ${STATE_B.javaClass.simpleName}!")
+                    .isThrownBy { stateMachine.transition(EVENT_1) }
+                    .withMessage("Missing definition for state ${STATE_B.javaClass.simpleName}!")
             }
         }
 

--- a/src/test/kotlin/com/tinder/StateMachineTest.kt
+++ b/src/test/kotlin/com/tinder/StateMachineTest.kt
@@ -709,7 +709,7 @@ internal class StateMachineTest {
             }
 
             @Test
-            fun transition_givenValidEvent_shouldReturnTrue() {
+            fun transition_givenMissingDestinationStateDefinition_shouldThrowIllegalStateExceptionWithStateName() {
                 // Then
                 try {
                     stateMachine.transition(EVENT_1)


### PR DESCRIPTION
When a state definition is missing, exception is thrown with message: `Required value is null`.
This fix adds more meaningful error message.

An example of missing state definition:
```
            private val stateMachine = StateMachine.create<String, Int, Nothing> {
                initialState(STATE_A)
                state(STATE_A) {
                    on(EVENT_1) {
                        transitionTo(STATE_B)
                    }
                }
                // Missing STATE_B definition.
            }
```
Error is thrown here:
```
stateMachine.transition(EVENT_1) // transition to `STATE_B` which is not handled.
```