### PR TITLE
Add parameter to enable throwing exception on invalid transition

### DIFF
--- a/src/test/kotlin/com/tinder/StateMachineTest.kt
+++ b/src/test/kotlin/com/tinder/StateMachineTest.kt
@@ -556,7 +556,6 @@ internal class StateMachineTest {
             private val onStateAExitListener2 = mock<String.(Int) -> Unit>()
             private val stateMachine = StateMachine.create<String, Int, String> {
                 initialState(STATE_A)
-                throwOnInvalidTransition() // TODO!
                 state(STATE_A) {
                     onExit(onStateAExitListener1)
                     onExit(onStateAExitListener2)
@@ -685,6 +684,28 @@ internal class StateMachineTest {
                     .isThrownBy {
                         stateMachine.transition(EVENT_4)
                     }
+            }
+        }
+
+        class ThrowingOnInvalidTransition {
+
+            private val stateMachine = StateMachine.create<String, Int, String> {
+                initialState(STATE_A)
+                throwOnInvalidTransition()
+                state(STATE_A) {}
+            }
+
+            @Test
+            fun transition_givenInvalidEvent_shouldThrowIllegalStateException() {
+                // When
+                val fromState = stateMachine.state
+
+                // Then
+                assertThatIllegalStateException().isThrownBy {
+                    stateMachine.transition(EVENT_3)
+                }
+                assertThat(stateMachine.state).isEqualTo(fromState)
+
             }
         }
 

--- a/src/test/kotlin/com/tinder/StateMachineTest.kt
+++ b/src/test/kotlin/com/tinder/StateMachineTest.kt
@@ -702,7 +702,7 @@ internal class StateMachineTest {
 
                 // Then
                 assertThatIllegalStateException().isThrownBy {
-                    stateMachine.transition(EVENT_3)
+                    stateMachine.transition(EVENT_1)
                 }
                 assertThat(stateMachine.state).isEqualTo(fromState)
 

--- a/src/test/kotlin/com/tinder/StateMachineTest.kt
+++ b/src/test/kotlin/com/tinder/StateMachineTest.kt
@@ -556,6 +556,7 @@ internal class StateMachineTest {
             private val onStateAExitListener2 = mock<String.(Int) -> Unit>()
             private val stateMachine = StateMachine.create<String, Int, String> {
                 initialState(STATE_A)
+                throwOnInvalidTransition() // TODO!
                 state(STATE_A) {
                     onExit(onStateAExitListener1)
                     onExit(onStateAExitListener2)


### PR DESCRIPTION
As proposed in https://github.com/Tinder/StateMachine/issues/9, invalid transition should cause an exception. In my opinion, current behavior (returning `Invalid` object) is a good solution, however users should be able to enable throwing exceptions in such cases.