### PR TITLE
Allow split state definitions

### DIFF
--- a/src/main/kotlin/com/tinder/StateMachine.kt
+++ b/src/main/kotlin/com/tinder/StateMachine.kt
@@ -51,7 +51,13 @@ class StateMachine<STATE : Any, EVENT : Any, SIDE_EFFECT : Any> private construc
     private fun STATE.getDefinition() = graph.stateDefinitions
         .filter { it.key.matches(this) }
         .map { it.value }
-        .firstOrNull() ?: error("Missing definition for state ${this.javaClass.simpleName}!")
+        .fold(Graph.State<STATE, EVENT, SIDE_EFFECT>()) { acc, state ->
+            acc.apply {
+                onEnterListeners.addAll(state.onEnterListeners)
+                onExitListeners.addAll(state.onExitListeners)
+                transitions.putAll(state.transitions)
+            }
+        }
 
     private fun STATE.notifyOnEnter(cause: EVENT) {
         getDefinition().onEnterListeners.forEach { it(this, cause) }


### PR DESCRIPTION
Consider the following state machine:

```kotlin
StateMachine.create<String, Int, Nothing> {
	initialState(STATE_A)

	state(STATE_A) {
		on(EVENT_1) {
			transitionTo(STATE_B)
		}

		onExit(firstDefinitionOnExitListener)
	}

	state(STATE_A) {
		on(EVENT_2) {
			transitionTo(STATE_B)
		}

		onExit(secondDefinitionOnExitListener)
	}

	state(STATE_B) {
		onEnter(firstDefinitionOnEnterListener)
	}

	state(STATE_B) {
		onEnter(secondDefinitionOnEnterListener)
	}
}
```

Currently, trying to transition from `STATE_A` on `EVENT_1` will result in a valid transition, but attempting a transition on `EVENT_2` will result in an invalid transition. There's no warning or error given neither for the second `STATE_A` nor the second `STATE_B` definitions. A similar behavior can be observed for on exit and on enter listeners - only `firstDefinitionOnExitListener` and `firstDefinitionOnEnterListener` will be called when transitioning from `STATE_A` to `STATE_B`.

This PR aims to make state machines take into account all the state definitions passed to the graph builder. This is achieved by merging all applicable state definitions when resolving a transition for a given state and event instead of just taking the first one that matches.