### PR TITLE
Patch 1 - updates README and podspec with latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,14 +198,14 @@ Snapshots of the development version are available in [Sonatype's `snapshots` re
 <dependency>
     <groupId>com.tinder.statemachine</groupId>
     <artifactId>statemachine</artifactId>
-    <version>0.3.0</version>
+    <version>0.2.0</version>
 </dependency>
 ```
 
 ### Gradle
 
 ```groovy
-implementation 'com.tinder.statemachine:statemachine:0.3.0'
+implementation 'com.tinder.statemachine:statemachine:0.2.0'
 ```
 
 ## Swift Installation
@@ -213,7 +213,7 @@ implementation 'com.tinder.statemachine:statemachine:0.3.0'
 ### Swift Package Manager
 
 ```
-.package(url: "https://github.com/Tinder/StateMachine.git", from: "0.3.0")
+.package(url: "https://github.com/Tinder/StateMachine.git", from: "0.2.0")
 ```
 
 ### Cocoapods

--- a/StateMachine.podspec
+++ b/StateMachine.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'StateMachine'
-  s.version  = '0.3.0'
+  s.version  = '0.2.0'
   s.summary  = 'A state machine library in Swift'
   s.homepage = 'https://github.com/Tinder/StateMachine'
   s.license  = { :type => 'BSD 3-Clause "New" or "Revised" License', :file => 'LICENSE' }


### PR DESCRIPTION
Does version 0.3.0 really exist? Maven only shows [0.2.0](https://mvnrepository.com/artifact/com.tinder.statemachine/statemachine) 🤔
